### PR TITLE
Add missing <array> header

### DIFF
--- a/src/geology.cpp
+++ b/src/geology.cpp
@@ -1,17 +1,19 @@
 #include "geology.h"
 
+#include <array>
+
 /**
  * @brief calculate arc distance
- * 
- * @param dLongitude_degree0 
- * @param dLatitude_degree0 
- * @param dLongitude_degree1 
- * @param dLatitude_degree1 
- * @return float 
+ *
+ * @param dLongitude_degree0
+ * @param dLatitude_degree0
+ * @param dLongitude_degree1
+ * @param dLatitude_degree1
+ * @return float
  */
-float calculate_distance_based_on_lon_lat_degree(float dLongitude_degree0, 
-float dLatitude_degree0, 
-float dLongitude_degree1, 
+float calculate_distance_based_on_lon_lat_degree(float dLongitude_degree0,
+float dLatitude_degree0,
+float dLongitude_degree1,
 float dLatitude_degree1)
 {
     float dDistance = 0.0;
@@ -19,21 +21,21 @@ float dLatitude_degree1)
     float dDelta_longitude_radian, dDelta_latitude_radian;
     float a, c, r;
 
-    //convert decimal degrees to radians 
-    
+    //convert decimal degrees to radians
+
     dLongitude_radian0 = convert_degree_to_radian(dLongitude_degree0);
     dLatitude_radian0 = convert_degree_to_radian(dLatitude_degree0);
 
     dLongitude_radian1 = convert_degree_to_radian(dLongitude_degree1);
     dLatitude_radian1 = convert_degree_to_radian(dLatitude_degree1);
 
-    //haversine formula 
+    //haversine formula
     dDelta_longitude_radian = dLongitude_radian1 - dLongitude_radian0;
     dDelta_latitude_radian = dLatitude_radian1 - dLatitude_radian0;
 
     a = sin(dDelta_latitude_radian/2)* sin(dDelta_latitude_radian/2) + cos(dLatitude_radian0) * cos(dLatitude_radian1) * sin(dDelta_longitude_radian/2)* sin(dDelta_longitude_radian/2);
-    c = 2 * asin(sqrt(a)); 
-    
+    c = 2 * asin(sqrt(a));
+
 
     r = dRadius_earth;
 
@@ -43,11 +45,11 @@ float dLatitude_degree1)
 
 /**
  * @brief calculate xyz location using lat/lon and elevation
- * 
- * @param dLongitude_radian 
- * @param dLatitude_radian 
- * @param dElevation 
- * @return std::array<float ,3> 
+ *
+ * @param dLongitude_radian
+ * @param dLatitude_radian
+ * @param dElevation
+ * @return std::array<float ,3>
  */
 std::array<float, 3>  calculate_location_based_on_lon_lat_radian(float dLongitude_radian, float dLatitude_radian, float dElevation)
 {
@@ -60,9 +62,9 @@ std::array<float, 3>  calculate_location_based_on_lon_lat_radian(float dLongitud
     float C      = 1/sqrt(cosLat*cosLat + FF * sinLat*sinLat);
     float S      = C * FF;
 
-    float x = (dRadius_earth * C + dElevation)*cosLat * cos(dLongitude_radian);
-    float y = (dRadius_earth * C + dElevation)*cosLat * sin(dLongitude_radian);
-    float z = (dRadius_earth * S + dElevation)*sinLat;
+    const float x = (dRadius_earth * C + dElevation)*cosLat * cos(dLongitude_radian);
+    const float y = (dRadius_earth * C + dElevation)*cosLat * sin(dLongitude_radian);
+    const float z = (dRadius_earth * S + dElevation)*sinLat;
 
     aLocation[0] = x;
     aLocation[1] = y;

--- a/src/json/vertex.cpp
+++ b/src/json/vertex.cpp
@@ -1,5 +1,7 @@
 #include "vertex.h"
 
+#include <array>
+
 namespace jsonmodel
 {
 
@@ -17,10 +19,10 @@ namespace jsonmodel
 
   /**
    * @brief overload the equal function
-   * 
-   * @param cVertex 
-   * @return true 
-   * @return false 
+   *
+   * @param cVertex
+   * @return true
+   * @return false
    */
 
   bool vertex::operator==(const vertex &cVertex)
@@ -39,9 +41,9 @@ namespace jsonmodel
 
   /**
    * @brief calculate the slope between two vertices
-   * 
-   * @param pVertex_in 
-   * @return float 
+   *
+   * @param pVertex_in
+   * @return float
    */
 
   float vertex::calculate_slope(vertex pVertex_in)
@@ -56,7 +58,7 @@ namespace jsonmodel
     y1 = pVertex_in.dy;
     z1 = pVertex_in.dz;
     dElevation1 = pVertex_in.dElevation;
-    dDistance=  calculate_distance(pVertex_in); 
+    dDistance=  calculate_distance(pVertex_in);
 
     if (this->dx != x1)
     {
@@ -84,8 +86,8 @@ namespace jsonmodel
   int vertex::update_location()
   {
     int error_code =1;
-    
-    std::array<float, 3> aLocation = calculate_location_based_on_lon_lat_radian(dLongitude_radian, dLatitude_radian, dElevation);
+
+    const auto aLocation = calculate_location_based_on_lon_lat_radian(dLongitude_radian, dLatitude_radian, dElevation);
     dx = aLocation[0];
     dy = aLocation[1];
     dz = aLocation[2];


### PR DESCRIPTION
The missing `array` header causes compilation failures on Macs.

Additional changes come from striping whitespace; IDEs should be configured to remove this automatically on save to make small changesets.