### PR TITLE
Remove unused variables, fix comparisons

### DIFF
--- a/src/compset/compset_direction.cpp
+++ b/src/compset/compset_direction.cpp
@@ -29,8 +29,6 @@ namespace hexwatershed
     int iFlag_elevation_profile = cParameter.iFlag_elevation_profile;
     long iNeighborIndex;
     long lCellID_lowest;
-    long lCellID_highest;
-    long lCellIndex_self;
     long lCellID;
     float dElevation_mean;
     float dElevation_profile0;
@@ -44,7 +42,6 @@ namespace hexwatershed
 
     long lCellIndex_neighbor;
     long lCellIndex_neighbor_lowest;
-    long lCellIndex_neighbor_highest;
     long lCellID_downstream;
 
     std::vector<float> vNeighbor_distance;
@@ -60,13 +57,12 @@ namespace hexwatershed
       if (iFlag_stream_burning_topology == 0)
       {
         // rely on elevation
-        for (lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
+        for (size_t lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
         {
           vNeighbor = (vCell_active.at(lCellIndex_self)).vNeighbor;
           vNeighbor_land = (vCell_active.at(lCellIndex_self)).vNeighbor_land;
           vNeighbor_distance = (vCell_active.at(lCellIndex_self)).vNeighbor_distance;
           lCellID_lowest = -1;
-          lCellID_highest = -1;
           dElevation_mean = (vCell_active.at(lCellIndex_self)).dElevation_mean;
           dSlope_downslope = dSlope_initial;
           dSlope_upslope = dSlope_initial;
@@ -101,7 +97,6 @@ namespace hexwatershed
               {
                 // this maybe a dominant upslope
                 dSlope_upslope = dSlope_new;
-                lCellID_highest = *iIterator_neighbor;
               }
             }
           }
@@ -131,14 +126,13 @@ namespace hexwatershed
       else
       {
         //#pragma omp parallel for private(lCellIndex_self, vNeighbor_land, lCellID_lowest, dElevation_mean, dSlope_initial, dSlope_new, iIterator_neighbor)
-        for (lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
+        for (size_t lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
         {
           vNeighbor = (vCell_active.at(lCellIndex_self)).vNeighbor;
           vNeighbor_distance = (vCell_active.at(lCellIndex_self)).vNeighbor_distance;
           iFlag_stream_burned = vCell_active[lCellIndex_self].iFlag_stream_burned;
           vNeighbor_land = (vCell_active.at(lCellIndex_self)).vNeighbor_land;
           lCellID_lowest = -1;
-          lCellID_highest = -1;
 
           dElevation_mean = (vCell_active.at(lCellIndex_self)).dElevation_mean;
           dElevation_profile0 = (vCell_active.at(lCellIndex_self)).dElevation_profile0;
@@ -211,8 +205,6 @@ namespace hexwatershed
                   {
                     // this maybe a dominant downslope
                     dSlope_upslope = dSlope_new;
-                    lCellID_highest = *iIterator_neighbor;
-                    lCellIndex_neighbor_highest = lCellIndex_self;
                   }
                 }
               }
@@ -249,8 +241,6 @@ namespace hexwatershed
                 {
                   // this maybe a dominant upslope
                   dSlope_upslope = dSlope_new;
-                  lCellID_highest = *iIterator_neighbor;
-                  lCellIndex_neighbor_highest = lCellIndex_self;
                 }
               }
             }
@@ -428,13 +418,12 @@ namespace hexwatershed
     {
       // pure dem based
       //#pragma omp parallel for private(lCellIndex_self, vNeighbor_land, lCellID_lowest, dElevation_mean, dSlope_initial, dSlope_new, iIterator_neighbor)
-      for (lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
+      for (size_t lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
       {
         vNeighbor = (vCell_active.at(lCellIndex_self)).vNeighbor;
         vNeighbor_distance = (vCell_active.at(lCellIndex_self)).vNeighbor_distance;
         vNeighbor_land = (vCell_active.at(lCellIndex_self)).vNeighbor_land;
         lCellID_lowest = -1;
-        lCellID_highest = -1;
         dElevation_mean = (vCell_active.at(lCellIndex_self)).dElevation_mean;
         dSlope_downslope = dSlope_initial;
         dSlope_upslope = dSlope_initial;
@@ -469,7 +458,6 @@ namespace hexwatershed
             {
               // this maybe a dominant downslope
               dSlope_upslope = dSlope_new;
-              lCellID_highest = *iIterator_neighbor;
             }
           }
         }

--- a/src/compset/compset_run.cpp
+++ b/src/compset/compset_run.cpp
@@ -23,7 +23,7 @@ namespace hexwatershed
     int error_code = 1;
     int iFlag_has_upslope = 0;
     int iFlag_all_upslope_done; //assume all are done
-    long lFlag_total = 0;
+    size_t lFlag_total = 0;
     long lCelllIndex_neighbor;
     long lCellID_downslope_neighbor;
     long lCellID_neighbor;
@@ -79,9 +79,9 @@ namespace hexwatershed
                       {
                       }
                   }
-               
+
                 //there are the ones have no upslope at all
-             
+
 
                 if (iFlag_has_upslope == 0)
                   {
@@ -136,7 +136,6 @@ namespace hexwatershed
   int compset::compset_define_stream_grid()
   {
     int error_code = 1;
-    long lCellIndex_self;
 
     //in watershed hydrology, a threshold is usually used to define the network
     //here we use similar method
@@ -149,28 +148,27 @@ namespace hexwatershed
 
     int iFlag_global = cParameter.iFlag_global;
     int iFlag_flowline = cParameter.iFlag_flowline;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     if (iFlag_global != 1)
       {
         if (iFlag_flowline == 1)
         {
           //use outlet id as largest
-          lCellID_outlet =  aBasin.at(0).lCellID_outlet;  
+          lCellID_outlet =  aBasin.at(0).lCellID_outlet;
           lCellIndex_outlet = compset_find_index_by_cellid(lCellID_outlet);
           dAccumulation_threshold = 0.05 * vCell_active.at(lCellIndex_outlet).dAccumulation;
-          //openmp may  not work for std container in earlier C++ 
+          //openmp may  not work for std container in earlier C++
           //#pragma omp parallel for private(lCellIndex_self)
-          for (lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
+          for (size_t lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
             {
               if ((vCell_active.at(lCellIndex_self)).dAccumulation >= dAccumulation_threshold)
                 {
-                  (vCell_active.at(lCellIndex_self)).iFlag_stream = 1;  
+                  (vCell_active.at(lCellIndex_self)).iFlag_stream = 1;
                   (vCell_active.at(lCellIndex_self)).dLength_stream_conceptual = (vCell_active.at(lCellIndex_self)).dResolution_effective;
                 }
               else
                 {
                   (vCell_active.at(lCellIndex_self)).iFlag_stream = 0;
-                  //we still need its length for MOSART model.    
+                  //we still need its length for MOSART model.
                   (vCell_active.at(lCellIndex_self)).dLength_stream_conceptual =  (vCell_active.at(lCellIndex_self)).dResolution_effective;
                 }
             }
@@ -179,7 +177,7 @@ namespace hexwatershed
         {
             //find the maximum accumulation
             dAccumulation_max = 0.0;
-            for (lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
+            for (size_t lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
             {
               if ((vCell_active.at(lCellIndex_self)).dAccumulation >= dAccumulation_max)
               {
@@ -189,26 +187,26 @@ namespace hexwatershed
             }
             dAccumulation_threshold = 0.05 * vCell_active.at(lCellIndex_outlet).dAccumulation;
 
-            for (lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
+            for (size_t lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
             {
               if ((vCell_active.at(lCellIndex_self)).dAccumulation >= dAccumulation_threshold)
                 {
-                  (vCell_active.at(lCellIndex_self)).iFlag_stream = 1;  
+                  (vCell_active.at(lCellIndex_self)).iFlag_stream = 1;
                   (vCell_active.at(lCellIndex_self)).dLength_stream_conceptual = (vCell_active.at(lCellIndex_self)).dResolution_effective;
                 }
               else
                 {
                   (vCell_active.at(lCellIndex_self)).iFlag_stream = 0;
-                  //we still need its length for MOSART model.    
+                  //we still need its length for MOSART model.
                   (vCell_active.at(lCellIndex_self)).dLength_stream_conceptual =  (vCell_active.at(lCellIndex_self)).dResolution_effective;
                 }
-            
+
 
             }
 
         }
 
-        
+
       }
     else
       {
@@ -230,9 +228,7 @@ namespace hexwatershed
   {
     int error_code = 1;
     int iFound_outlet;
-    long lCellIndex_self;
     long lCellIndex_current;
-    long lCellIndex_downslope;
     long lCellIndex_outlet;
     long lCellID_downslope;
     long lCellID_outlet;
@@ -241,7 +237,6 @@ namespace hexwatershed
     std::vector<hexagon>::iterator iIterator_self;
 
     int iFlag_global = cParameter.iFlag_global;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     if (iFlag_global != 1)
       {
         //find the max accumulation outlet
@@ -263,8 +258,8 @@ namespace hexwatershed
 
         //#pragma omp parallel for private(lCellIndex_self, iFound_outlet, lIndex_downslope, lCellIndex_current)
         //can also use
-        for (lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
-          {            
+        for (size_t lCellIndex_self = 0; lCellIndex_self < vCell_active.size(); lCellIndex_self++)
+          {
             iFound_outlet = 0;
             lCellIndex_current = lCellIndex_self;
             while (iFound_outlet != 1)
@@ -319,7 +314,6 @@ namespace hexwatershed
     long lCellIndex_downstream;
     std::vector<hexagon>::iterator iIterator_self;
     int iFlag_global = cParameter.iFlag_global;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     if (iFlag_global != 1)
       {
 
@@ -370,7 +364,7 @@ namespace hexwatershed
       }
     else
       {
-        
+
       }
 
     return error_code;
@@ -392,7 +386,6 @@ namespace hexwatershed
     long lCellIndex_current;
     long lCellID_upstream;
     int iFlag_global = cParameter.iFlag_global;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     if (iFlag_global != 1)
       {
 
@@ -492,7 +485,6 @@ namespace hexwatershed
     std::vector<hexagon> vReach_segment;
 
     int iFlag_global = cParameter.iFlag_global;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     if (iFlag_global != 1)
       {
 
@@ -628,12 +620,10 @@ namespace hexwatershed
     int error_code = 1;
     int iFound_outlet;
     int iSubbasin;
-    long lCellIndex_self;
     long lCellIndex_current;
     long lCellID_outlet;
     long lCellIndex_outlet; //local outlet
     long lCellID_downslope;
-    long lCellIndex_downslope;
     long lCellIndex_accumulation;
     std::vector<long> vAccumulation;
     std::vector<long>::iterator iterator_accumulation;
@@ -642,7 +632,6 @@ namespace hexwatershed
     std::vector<long>::iterator iIterator_upstream;
     std::vector<hexagon>::iterator iIterator_current;
     int iFlag_global = cParameter.iFlag_global;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     if (iFlag_global != 1)
       {
 
@@ -678,13 +667,13 @@ namespace hexwatershed
                 iSubbasin = (vCell_active.at(lCellIndex_outlet)).iSegment;
                 (vCell_active.at(lCellIndex_outlet)).iSubbasin = iSubbasin;
 
-                for (iIterator_self = vCell_active.begin(); iIterator_self != vCell_active.end(); iIterator_self++)           
+                for (iIterator_self = vCell_active.begin(); iIterator_self != vCell_active.end(); iIterator_self++)
                   {
                     iFound_outlet = 0;
-                    lCellIndex_current =  (*iIterator_self).lCellIndex;      
+                    lCellIndex_current =  (*iIterator_self).lCellIndex;
                     while (iFound_outlet != 1)
-                      {                        
-                        lCellID_downslope = vCell_active.at(lCellIndex_current).lCellID_downslope_dominant;                        
+                      {
+                        lCellID_downslope = vCell_active.at(lCellIndex_current).lCellID_downslope_dominant;
                         if (lCellID_outlet == lCellID_downslope)
                           {
                             iFound_outlet = 1;
@@ -711,7 +700,7 @@ namespace hexwatershed
                                 //std::cout << lCellID_downslope << std::endl;
                               }
                             }
-                            
+
                           }
                       }
                   }
@@ -751,16 +740,15 @@ namespace hexwatershed
   }
 
   /**
-   * @brief 
-   * 
-   * @return int 
+   * @brief
+   *
+   * @return int
    */
 
   int compset::compset_calculate_watershed_characteristics()
   {
     int error_code = 1;
     int iFlag_global = cParameter.iFlag_global;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     if (iFlag_global != 1)
       {
         cWatershed.calculate_watershed_characteristics();
@@ -773,9 +761,9 @@ namespace hexwatershed
   }
 
 /**
- * @brief 
- * 
- * @return int 
+ * @brief
+ *
+ * @return int
  */
   int compset::update_cell_elevation()
   {
@@ -789,23 +777,22 @@ namespace hexwatershed
   }
 
   /**
-   * @brief 
-   * 
-   * @return int 
+   * @brief
+   *
+   * @return int
    */
   int compset::update_vertex_elevation()
   {
     int error_code = 1;
-    long lVertexIndex = 0;
     std::vector<hexagon>::iterator iIterator1;
     std::vector<vertex>::iterator iIterator2;
     std::vector<vertex>::iterator iIterator3;
 
     for (iIterator2 = vVertex_active.begin(); iIterator2 != vVertex_active.end(); ++iIterator2)
     {
-    
+
       for (iIterator1 = vCell_active.begin(); iIterator1 != vCell_active.end(); ++iIterator1)
-      {          
+      {
          iIterator3 = std::find((*iIterator1).vVertex.begin(), (*iIterator1).vVertex.end(), ( *iIterator2 ));
 
           if (iIterator3 != (*iIterator1).vVertex.end())
@@ -822,8 +809,8 @@ namespace hexwatershed
       }
 
     }
-      
-    
+
+
     return error_code;
   }
 

--- a/src/compset/compset_save.cpp
+++ b/src/compset/compset_save.cpp
@@ -21,7 +21,6 @@ namespace hexwatershed
   {
     int error_code = 1;
     int iFlag_global = cParameter.iFlag_global;
-    int iFlag_multiple_outlet = cParameter.iFlag_multiple_outlet;
     //update vertex first
     update_cell_elevation();
     update_vertex_elevation();
@@ -106,7 +105,7 @@ namespace hexwatershed
                 pCell.dLatitude_center_degree = (*iIterator).dLatitude_center_degree;
                 pCell.dSlope_between = (*iIterator).dSlope_max_downslope;
                 pCell.dSlope_profile = (*iIterator).dSlope_elevation_profile0;
-                
+
                 //pCell.dSlope_within = (*iIterator).dSlope_within;
                 pCell.dElevation_mean = (*iIterator).dElevation_mean;
                 pCell.dElevation_raw = (*iIterator).dElevation_raw;
@@ -133,7 +132,7 @@ namespace hexwatershed
             pCell.dLongitude_center_degree = (*iIterator).dLongitude_center_degree;
             pCell.dLatitude_center_degree = (*iIterator).dLatitude_center_degree;
             pCell.dSlope_between = (*iIterator).dSlope_max_downslope;
- 
+
             pCell.dSlope_within = (*iIterator).dSlope_within;
             pCell.dElevation_raw = (*iIterator).dElevation_raw;
             pCell.dElevation_mean = (*iIterator).dElevation_mean;
@@ -340,16 +339,10 @@ namespace hexwatershed
                                             std::string sLayername_in)
   {
     int error_code = 1;
-    int iValue;
-    int iReach;
     int iFlag_debug = cParameter.iFlag_debug;
     int iFlag_merge_reach = cParameter.iFlag_merge_reach;
-    long lIndex;
 
     long lIndex_downslope;
-    float dx, dy;
-    float dX_start, dY_start;
-    float dX_end, dY_end;
     std::vector<hexagon> vReach_segment;
     std::vector<hexagon>::iterator iIterator;
 
@@ -530,9 +523,6 @@ namespace hexwatershed
       default:
         break;
       }
-    int iValue;
-    float dValue;
-
 
     if (iFlag_debug == 1)
       {
@@ -571,11 +561,10 @@ namespace hexwatershed
     int error_code = 1;
     int iVertex;
     int iFlag_debug = cParameter.iFlag_debug;
-    long lValue;
     long lCount;
     long lCellID, lCellIndex;
     long nVertex, nHexagon, nBoundary;
-    float dr, dx, dy, dz;
+    float dx, dy, dz;
     std::string sDummy;
     std::string sLine;
     std::string sPoint, sCell, sCell_size;

--- a/src/compset/compset_stream.cpp
+++ b/src/compset/compset_stream.cpp
@@ -21,9 +21,7 @@ namespace hexwatershed
   int compset::compset_stream_burning_without_topology(long lCellID_center_in)
   {
     int error_code = 1;
-    int iFlag_stream_burned;
     int iFlag_stream_burned_neighbor;
-    int iFlag_stream_burning_treated;
     int iFlag_stream_burning_treated_neighbor;
 
     int untreated;
@@ -142,22 +140,14 @@ namespace hexwatershed
   {
     int error_code = 1;
     int iFlag_elevation_profile = cParameter.iFlag_elevation_profile;
-    int iOption_filling = 1;
-    int iFlag_finished;
 
-    int iFlag_stream_burned;
     int iFlag_stream_burned_neighbor;
 
-    int iFlag_stream_burning_treated;
     int iFlag_stream_burning_treated_neighbor;
 
     int iStream_order_center;
     int iStream_order_neighbor;
-    long lIndex_outlet;
-    long lIndex_lowest;
-    long lCellIndex_active;
     long lCellIndex_neighbor;
-    long lIndex_current;
     long lIndex_center_next;
     long lCellID_current;
     long lCellID_downstream_burned;
@@ -198,7 +188,7 @@ namespace hexwatershed
         dDifference_dummy = dElevation_mean_neighbor - dElevation_mean_center;
         if (dDifference_dummy >= 0)
         {
-          
+
         }
         else
         {
@@ -304,7 +294,6 @@ namespace hexwatershed
     int error_code = 1;
     // int iStream_order_neighbor;
     // int iStream_order_center;
-    long lCellID;
     long lCellIndex_active;
     long lCellID2, lCellID3;
     long lCellIndex2, lCellIndex3;
@@ -316,32 +305,24 @@ namespace hexwatershed
     long lCellID_next;
 
     int iFlag_finished = 0;
-    int iFlag_found;
-    int iFlag_found1;
     float dDifference_dummy;
-    float dElevation_before;
-    float dElevation_after;
-    float dElevation_dummy;
     // std::vector<hexagon>::iterator iIterator2;
     // std::vector<hexagon>::iterator iIterator3;
     lCellIndex_active = compset_find_index_by_cellid(lCellID_active_in);
     while (iFlag_finished != 1)
     {
-      lCellID = vCell_active.at(lCellIndex_active).lCellID;
       lCellID_downstream = vCell_active.at(lCellIndex_active).lCellID_downstream_burned;
       dElevation_upstream = vCell_active.at(lCellIndex_active).dElevation_mean;
       // iStream_order_neighbor = vCell_active.at(lCellIndex_active).iStream_order_burned;
       if (lCellID_downstream != -1)
       {
-        iFlag_found = 0;
         // for (iIterator2 = vCell_active.begin (); iIterator2 != vCell_active.end (); iIterator2++)
-        for (long lIndex2 = 0; lIndex2 < vCell_active.size(); lIndex2++)
+        for (size_t lIndex2 = 0; lIndex2 < vCell_active.size(); lIndex2++)
         {
           lCellIndex2 = vCell_active.at(lIndex2).lCellIndex;
           lCellID2 = vCell_active.at(lCellIndex2).lCellID;
           if (lCellID2 == lCellID_downstream)
           {
-            iFlag_found = 1;
             dElevation_downstream = vCell_active.at(lCellIndex2).dElevation_mean;
             // dElevation_before = dElevation_downstream;
             //  iStream_order_center = (*iIterator2).iStream_order_burned;
@@ -361,15 +342,13 @@ namespace hexwatershed
               lCellID_downstream2 = vCell_active.at(lCellIndex2).lCellID_downstream_burned;
               if (lCellID_downstream2 != -1)
               {
-                iFlag_found1 = 0;
                 // for (iIterator3 = vCell_active.begin (); iIterator3 != vCell_active.end (); iIterator3++)
-                for (long lIndex3 = 0; lIndex3 < vCell_active.size(); lIndex3++)
+                for (size_t lIndex3 = 0; lIndex3 < vCell_active.size(); lIndex3++)
                 {
                   lCellIndex3 = vCell_active.at(lIndex3).lCellIndex;
                   lCellID3 = vCell_active.at(lCellIndex3).lCellID;
                   if (lCellID3 == lCellID_downstream2)
                   {
-                    iFlag_found1 = 1;
                     dDifference_dummy = vCell_active.at(lCellIndex2).dElevation_mean - vCell_active.at(lCellIndex3).dElevation_mean;
                     if (dDifference_dummy < 0.0) // another depression
                     {

--- a/src/domain/domain.cpp
+++ b/src/domain/domain.cpp
@@ -12,13 +12,6 @@
 
 namespace hexwatershed
 {
-
-  domain::domain(){
-
-  };
-
-  domain::~domain(){};
-
   /**
    *
    * @param sFilename_configuration_in: user provided model configuration file
@@ -75,8 +68,8 @@ namespace hexwatershed
 
   int domain::domain_initialize ()
   {
-    int error_code=1;  
-    
+    int error_code=1;
+
     cCompset.compset_initialize_model();
     //the last outlet need to be set
 

--- a/src/domain/domain.h
+++ b/src/domain/domain.h
@@ -49,15 +49,13 @@ namespace hexwatershed
 {
   class domain {
   public:
-    domain ();
     domain (std::string sFilename_configuration_in);
-    ~domain ();
 
     std::string sWorkspace_input;
     std::string sWorkspace_output;
     std::string sWorkspace_output_pyflowline;
     std::string sWorkspace_output_hexwatershed;
-    
+
     std::string sFilename_log;
     std::string sLog;
 
@@ -99,8 +97,8 @@ namespace hexwatershed
     //vtk support
     std::string sFilename_vtk;
     std::string sFilename_vtk_debug;
-    
-  
+
+
 
     //others
     std::string sDate_default;

--- a/src/domain/domain_read.cpp
+++ b/src/domain/domain_read.cpp
@@ -39,7 +39,6 @@ namespace hexwatershed
   int domain::domain_read_configuration_file()
   {
     int error_code = 1;
-    std::size_t iVector_size;
     std::string sLine;  // used to store each sLine
     std::string sKey;   // used to store the sKey
     std::string sValue; // used to store the sValue
@@ -79,41 +78,19 @@ namespace hexwatershed
     {
       sMesh_type = pConfigDoc[sKey.c_str()].GetString();
     }
-    if (sMesh_type == "hexagon")
-    {
+
+    if (sMesh_type == "hexagon") {
       iMesh_type = 1;
-    }
-    else
-    {
-      if (sMesh_type == "square")
-      {
-        iMesh_type = 2;
-      }
-      else
-      {
-        if (sMesh_type == "latlon")
-        {
-          iMesh_type = 3;
-        }
-        else
-        {
-          if (sMesh_type == "mpas")
-          {
-            iMesh_type = 4;
-          }
-          else
-          {
-            if (sMesh_type == "tin")
-            {
-              iMesh_type = 5;
-            }
-            else
-            {
-              std::cout << "Unsupported mesh type" << std::endl;
-            }
-          }
-        }
-      }
+    } else if (sMesh_type == "square") {
+      iMesh_type = 2;
+    } else if (sMesh_type == "latlon") {
+      iMesh_type = 3;
+    } else if (sMesh_type == "mpas") {
+      iMesh_type = 4;
+    } else if (sMesh_type == "tin") {
+      iMesh_type = 5;
+    } else {
+      throw std::runtime_error("Unsupported mesh type!");
     }
 
     cCompset.cParameter.sMesh_type = sMesh_type;
@@ -317,8 +294,6 @@ namespace hexwatershed
   {
     int error_code = 1;
     int iMesh_type = cCompset.cParameter.iMesh_type;
-    int iFlag_flowline = cCompset.cParameter.iFlag_flowline;
-    int iFlag_stream_burning_topology = cCompset.cParameter.iFlag_stream_burning_topology;
     std::vector<hexagon>::iterator iIterator;
     switch (iMesh_type)
     {

--- a/src/json/mesh.h
+++ b/src/json/mesh.h
@@ -7,16 +7,16 @@ namespace jsonmodel
 {
   class mesh : public JSONBase
   {
-  public:		
+  public:
    //mesh() {};
     virtual ~mesh() {};
-    virtual bool Deserialize(const std::string& s);		
+    virtual bool Deserialize(const std::string& s);
 
     std::list<cell> aCell;
   public:
-    virtual bool Deserialize(const rapidjson::Value& obj) { return false; };
+    virtual bool Deserialize(const rapidjson::Value&) { return false; };
     virtual bool Serialize(rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) const;
   private:
-    
+
   };
 }

--- a/src/json/multibasin.h
+++ b/src/json/multibasin.h
@@ -7,16 +7,16 @@ namespace jsonmodel
 {
   class multibasin : public JSONBase
   {
-  public:		
+  public:
    //multibasin() {};
     virtual ~multibasin() {};
-    virtual bool Deserialize(const std::string& s);		
+    virtual bool Deserialize(const std::string& s);
 
     std::list<basin> aBasin;
   public:
-    virtual bool Deserialize(const rapidjson::Value& obj) { return false; };
+    virtual bool Deserialize(const rapidjson::Value&) { return false; };
     virtual bool Serialize(rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) const;
   private:
-    
+
   };
 }

--- a/src/json/vertex.cpp
+++ b/src/json/vertex.cpp
@@ -17,10 +17,10 @@ namespace jsonmodel
 
   /**
    * @brief overload the equal function
-   * 
-   * @param cVertex 
-   * @return true 
-   * @return false 
+   *
+   * @param cVertex
+   * @return true
+   * @return false
    */
 
   bool vertex::operator==(const vertex &cVertex)
@@ -39,24 +39,19 @@ namespace jsonmodel
 
   /**
    * @brief calculate the slope between two vertices
-   * 
-   * @param pVertex_in 
-   * @return float 
+   *
+   * @param pVertex_in
+   * @return float
    */
 
   float vertex::calculate_slope(vertex pVertex_in)
   {
     float dSlope = 0.0;
-    float x1;
-    float y1;
-    float z1;
     float dElevation1;
     float dDistance;
-    x1 = pVertex_in.dx;
-    y1 = pVertex_in.dy;
-    z1 = pVertex_in.dz;
+    const float x1 = pVertex_in.dx;
     dElevation1 = pVertex_in.dElevation;
-    dDistance=  calculate_distance(pVertex_in); 
+    dDistance=  calculate_distance(pVertex_in);
 
     if (this->dx != x1)
     {
@@ -70,21 +65,18 @@ namespace jsonmodel
   }
   float vertex::calculate_distance(vertex pVertex_in)
   {
-    float dDistance = 0.0;
-    float dLon0 = this->dLongitude_degree;
-    float dLat0 = this->dLatitude_degree;
-    float dLon1 = pVertex_in.dLongitude_degree;
-    float dLat1 = pVertex_in.dLatitude_degree;
+    const float dLon0 = this->dLongitude_degree;
+    const float dLat0 = this->dLatitude_degree;
+    const float dLon1 = pVertex_in.dLongitude_degree;
+    const float dLat1 = pVertex_in.dLatitude_degree;
 
-    dDistance = calculate_distance_based_on_lon_lat_degree(dLon0, dLat0, dLon1, dLat1);
-
-    return dDistance;
+    return calculate_distance_based_on_lon_lat_degree(dLon0, dLat0, dLon1, dLat1);
   }
 
   int vertex::update_location()
   {
     int error_code =1;
-    
+
     std::array<float, 3> aLocation = calculate_location_based_on_lon_lat_radian(dLongitude_radian, dLatitude_radian, dElevation);
     dx = aLocation[0];
     dy = aLocation[1];

--- a/src/watershed.cpp
+++ b/src/watershed.cpp
@@ -1,12 +1,12 @@
 /**
  * @file watershed.cpp
  * @author Chang Liao (chang.liao@pnnl.gov)
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2019-08-02
- * 
+ *
  * @copyright Copyright (c) 2019
- * 
+ *
  */
 
 #include "watershed.h"
@@ -143,7 +143,7 @@ namespace hexwatershed
 
     std::vector<segment>::iterator iIterator0;
     std::vector<subbasin>::iterator iIterator1;
-    
+
 
     for (iIterator0 = vSegment.begin(); iIterator0 != vSegment.end(); iIterator0++)
     {
@@ -167,7 +167,7 @@ namespace hexwatershed
 
     //save watershed characteristics to the file
 
-    
+
 
     std::cout << "The watershed characteristics are calculated successfully!" << std::endl;
 
@@ -184,7 +184,7 @@ namespace hexwatershed
     int error_code = 1;
     int iOption = 2; //sum up subbasin
 
-    float dArea_total = 0.0;    
+    float dArea_total = 0.0;
     std::vector<hexagon>::iterator iIterator;
     std::vector<subbasin>::iterator iIterator1;
     if (iOption == 1)
@@ -201,7 +201,7 @@ namespace hexwatershed
 
         dArea_total = dArea_total + (*iIterator1).dArea;
       }
-    }    
+    }
     dArea = dArea_total;
     return error_code;
   }
@@ -221,21 +221,21 @@ namespace hexwatershed
     std::vector<segment>::iterator iIterator1;
     if (iOption == 1)
     {
-      for (iIterator = vCell.begin(); iIterator != vCell.end(); iIterator++)
+      for (const auto &vc : vCell)
       {
 
-        if ((*iIterator).iFlag_stream == 1)
+        if (vc.iFlag_stream == 1)
         {
           //should have calculated dLength_stream_conceptual by now
-          dLength_total = dLength_total + (*iIterator).dLength_stream_conceptual;
+          dLength_total = dLength_total + vc.dLength_stream_conceptual;
         }
       }
     }
     else
     {
-      for (iIterator1 = vSegment.begin(); iIterator1 != vSegment.end(); iIterator1++)
+      for (const auto &vs : vSegment)
       {
-        dLength_total = dLength_total + (*iIterator1).dLength;
+        dLength_total = dLength_total + vs.dLength;
       }
     }
 
@@ -256,11 +256,9 @@ namespace hexwatershed
     float dLength_stream_conceptual;
 
     //loop through head water
-    std::vector<segment>::iterator iIterator;
-
-    for (iIterator = vSegment.begin(); iIterator != vSegment.end(); iIterator++)
+    for (const auto &vs: vSegment)
     {
-      dLength_stream_conceptual = (*iIterator).dLength;
+      dLength_stream_conceptual = vs.dLength;
       if (dLength_stream_conceptual > dLength_longest)
       {
         dLength_longest = dLength_stream_conceptual;
@@ -304,20 +302,18 @@ namespace hexwatershed
     int error_code = 1;
     int iOption = 1;
     float dSlope_total = 0.0;
-    std::vector<hexagon>::iterator iIterator;
-    std::vector<subbasin>::iterator iIterator1;
     if (iOption == 1)//by cell
     {
-      for (iIterator = vCell.begin(); iIterator != vCell.end(); iIterator++)
+      for (const auto &vc: vCell)
       {
-        dSlope_total = dSlope_total + (*iIterator).dSlope_within; //should mean slope?
+        dSlope_total = dSlope_total + vc.dSlope_within; //should mean slope?
       }
     }
     else//by subbasin
     {
-      for (iIterator1 = vSubbasin.begin(); iIterator1 != vSubbasin.end(); iIterator1++)
+      for (const auto &vs: vSubbasin)
       {
-        dSlope_total = dSlope_total + (*iIterator1).dSlope;
+        dSlope_total = dSlope_total + vs.dSlope;
       }
     }
 
@@ -334,11 +330,6 @@ namespace hexwatershed
   int watershed::calculate_topographic_wetness_index()
   {
     int error_code = 1;
-    float a;
-    float b;
-    float c;
-    float d;
-    float dTwi;
     std::vector<hexagon>::iterator iIterator;
     //can use openmp
     for (iIterator = vCell.begin(); iIterator != vCell.end(); iIterator++)
@@ -349,14 +340,14 @@ namespace hexwatershed
       }
       else
       {
-        a = float(((*iIterator).dAccumulation ) );
-        b = (*iIterator).dSlope;
-        c = tan(b);
+        const float a = float(((*iIterator).dAccumulation ) );
+        const float b = (*iIterator).dSlope;
+        const float c = tan(b);
         if (a == 0 || c == 0)
         {
           std::cout << a << b << c << std::endl;
         }
-        dTwi = log2(a / c);
+        const float dTwi = log2(a / c);
         if (isnan(float(dTwi)))
         {
           std::cout << a << b << c << std::endl;


### PR DESCRIPTION
There are many unused variables; this makes the code more difficult to read.

There are also many comparison between signed and unsigned variables; such comparisons are error-prone.

This PR removes most of the unused variables and fixes said comparisons along with other code cleaning.